### PR TITLE
Handle files with special chars in PrependBasePathFileProvider

### DIFF
--- a/src/Dazinator.Extensions.FileProviders.Tests/PrependBasePathFileProviderTests.cs
+++ b/src/Dazinator.Extensions.FileProviders.Tests/PrependBasePathFileProviderTests.cs
@@ -152,5 +152,64 @@ namespace Dazinator.Extensions.FileProviders.Tests
 
             afterFileChangeEvent.WaitOne(timeout);
         }
+
+        [Theory]
+        [InlineData("", "/somepath", "/somepath/TestDir/TestFile.txt", "/TestDir/TestFile.txt")]
+        [InlineData("TestDir", "/foo", "/foo/AnotherFolder/AnotherTestFile.txt", "/AnotherFolder/AnotherTestFile.txt")]
+        [InlineData("TestDir", "/foo", "/foo/AnotherFolder/TestFileWithSpecialCharsInName (ÆØÅ).txt", "/AnotherFolder/TestFileWithSpecialCharsInName (ÆØÅ).txt")]
+        public void Can_Get_File_Info(string rootFolderDir, string prependBasePath, string requestPath, string physicalPathForCompare)
+        {
+            // Arrange
+            var dir = Directory.GetCurrentDirectory();
+            var rootDir = Path.Combine(dir, rootFolderDir);
+            var physicalFileProvider = new PhysicalFileProvider(rootDir);
+
+            var sut = new PrependBasePathFileProvider(prependBasePath, physicalFileProvider);
+
+            // Act
+            var file = sut.GetFileInfo(requestPath);
+            // var fileList = files.ToList();
+            // Assert
+            Assert.True(file.Exists);
+            var expectedFile = physicalFileProvider.GetFileInfo(physicalPathForCompare);
+            Assert.Equal(expectedFile.PhysicalPath, file.PhysicalPath);
+        }
+
+        [Theory]
+        [InlineData("TestFile")]
+        [InlineData("TestFileWithSpecialCharsInName (ÆØÅ)")]
+        public void Can_Watch_A_Physical_File_With_Special_Characters_For_Changes(string fileName)
+        {
+            // arrange
+            var dir = Directory.GetCurrentDirectory();
+            var rootDir = Path.Combine(dir, "TemporaryTestDir");
+            Directory.CreateDirectory(rootDir);
+
+            var tempFileName = fileName + DateTime.Now.Ticks + ".txt";
+            var tempFilePhysicalFilePath = Path.Combine(rootDir, tempFileName);
+            File.WriteAllText(tempFilePhysicalFilePath, "Some file content");
+            
+            var physicalFileProvider = new PhysicalFileProvider(rootDir);
+            var sut = new PrependBasePathFileProvider("/somepath", physicalFileProvider);
+
+            // act
+            var token = sut.Watch("/somepath/" + tempFileName);
+
+            var afterFileChangeEvent = new ManualResetEvent(false);
+            var changeFired = false;
+            token.RegisterChangeCallback((a) =>
+            {
+                afterFileChangeEvent.Set();
+                changeFired = true;
+            }, null);
+
+            // Modify the file. Should trigger the change token callback as we are watching the file.
+            File.WriteAllText(tempFilePhysicalFilePath, "Some more file content");
+            // Assert
+            afterFileChangeEvent.WaitOne(new TimeSpan(0, 0, 1));
+            Assert.True(changeFired);
+            
+            Directory.Delete(rootDir, true);
+        }
     }
 }

--- a/src/Dazinator.Extensions.FileProviders/PrependBasePath/PrependBasePathFileProvider.cs
+++ b/src/Dazinator.Extensions.FileProviders/PrependBasePath/PrependBasePathFileProvider.cs
@@ -72,7 +72,7 @@ namespace Dazinator.Extensions.FileProviders.PrependBasePath
             PathString newPath;
             if (TryMapSubPath(subpath, out newPath))
             {
-                var result = _underlyingFileProvider.GetFileInfo(newPath);
+                var result = _underlyingFileProvider.GetFileInfo(newPath.Value);
                 return result;
             }
 
@@ -86,7 +86,7 @@ namespace Dazinator.Extensions.FileProviders.PrependBasePath
             PathString newPath;
             if (TryMapSubPath(filter, out newPath))
             {
-                var result = _underlyingFileProvider.Watch(newPath);
+                var result = _underlyingFileProvider.Watch(newPath.Value);
                 return result;
             }
 


### PR DESCRIPTION
Hi 😄 

We're experiencing issues serving files with special characters (like æ, ø, å, ä, ö etc.) using `PrependBasePathFileProvider`. 

Some debugging revealed that the requested file paths are URL encoded when querying the underlying file system in `GetFileInfo()`. This happens because the `PathString` is passed directly, triggering the implicit string operator which ultimately calls `ToUriComponent()` on the `PathString` instance.

Explicitly using `PathString.Value` seems to fix this.

For reference: This is somewhat in line with the ImageSharp issue fix [here](https://github.com/SixLabors/ImageSharp.Web/pull/279)

I do hope this makes sense?